### PR TITLE
Fix error running 'truffle test' on clean install with Node v9.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "hswick",
   "license": "ISC",
   "dependencies": {
+    "ethereumjs-util": "^5.1.5",
     "web3": "^1.0.0-beta.30"
   }
 }


### PR DESCRIPTION
After following the Installation steps in the Readme on a clean installation of Ubuntu 16.04 and Node v9.11.1, running `truffle test` results in the error:

```
Error: Cannot find module 'ethereumjs-util'
```

To solve this, I ran `npm install ethereumjs-util`. It produced the change in this commit.

After applying this commit, clearing `node_modules/` and re-running `npm install`, `truffle test` produces the output:

```
14 passing (3s)
```
