### PR TITLE
Add license and copyright headers

### DIFF
--- a/LICENSE-MIT.txt
+++ b/LICENSE-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 TrueBit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contracts/BasicVerificationGame.sol
+++ b/contracts/BasicVerificationGame.sol
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 pragma solidity ^0.4.18;
 
 import './IComputationLayer.sol';

--- a/contracts/IComputationLayer.sol
+++ b/contracts/IComputationLayer.sol
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 pragma solidity ^0.4.18;
 
 interface IComputationLayer {

--- a/contracts/IDisputeResolutionLayer.sol
+++ b/contracts/IDisputeResolutionLayer.sol
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 pragma solidity ^0.4.18;
 
 //TODO: Should maybe enforce checkProofOrdered

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 pragma solidity ^0.4.17;
 
 contract Migrations {

--- a/migrations/3_deploy_test_contracts.js
+++ b/migrations/3_deploy_test_contracts.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 const SimpleAdderVM = artifacts.require("./test/SimpleAdderVM.sol")
 
 module.exports = function(deployer) {

--- a/test/basic_verification_game.js
+++ b/test/basic_verification_game.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 const BasicVerificationGame = artifacts.require("./BasicVerificationGame.sol")
 const SimpleAdderVM = artifacts.require("./test/SimpleAdderVM.sol")
 const web3 = require('web3')

--- a/test/helpers/merkleTree.js
+++ b/test/helpers/merkleTree.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 //https://github.com/ameensol/merkle-tree-solidity/blob/master/js/merkle.js
 
 // https://github.com/raiden-network/raiden/blob/master/raiden/mtree.py

--- a/test/helpers/mineBlocks.js
+++ b/test/helpers/mineBlocks.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 module.exports = async (web3, n) => {
   for(let i = 0; i < n; i++) {
     await new Promise((resolve, reject) => {

--- a/test/merkle_proofs.js
+++ b/test/merkle_proofs.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 const BasicVerificationGame = artifacts.require("./BasicVerificationGame.sol")
 const web3 = require('web3')
 const merkleTree = require('./helpers/merkleTree')

--- a/test/simple_adder_vm.js
+++ b/test/simple_adder_vm.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 const SimpleAdderVM = artifacts.require("./test/SimpleAdderVM.sol")
 const web3 = require('web3')
 

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 TrueBit
+// See Copyright Notice in LICENSE-MIT.txt
+
 const BasicVerificationGame = artifacts.require("./BasicVerificationGame.sol")
 const SimpleAdderVM = artifacts.require("./test/SimpleAdderVM.sol")
 const Web3 = require('web3')


### PR DESCRIPTION
This adds a license file and copyright headers to the substantial source files.

The copyright header is:

```c++
// Copyright (C) 2018 TrueBit
// See Copyright Notice in LICENSE-MIT.txt
```

Normally we'd include the entire MIT license text in the source file header, but deploying source code to the blockchain has tangible costs, so I got a little tricky. Only `Copyright <year>` or `© <year>` are needed to explicitly claim copyright (copyright law makes no distinction about `(C)`). So instead of including the long text I just added MIT to the filename, which conveys the same information in a more concise form. (IANAL)
